### PR TITLE
feat: initial Hansabit monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Node
+node_modules
+.next
+pnpm-lock.yaml
+
+# Python
+__pycache__
+*.pyc
+.env
+.env.*
+.venv
+
+# Byte-compiled / optimized / DLL files
+*.py[cod]
+*.so
+
+# virtualenv
+venv/
+
+# testing
+.coverage
+pytest_cache/
+
+# Docker
+volumes/
+
+# macOS
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.PHONY: up down logs migrate seed test fmt lint
+
+up:
+docker-compose up -d --build
+
+down:
+docker-compose down
+
+logs:
+docker-compose logs -f
+
+migrate:
+docker-compose run --rm backend alembic upgrade head
+
+seed:
+docker-compose run --rm backend python app/db/init_db.py
+
+test:
+docker-compose run --rm backend pytest && docker-compose run --rm frontend npm test
+
+fmt:
+docker-compose run --rm backend black app && docker-compose run --rm frontend npm run fmt
+
+lint:
+docker-compose run --rm backend ruff app && docker-compose run --rm frontend npm run lint

--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
-# ai
+# Hansabit Monorepo
+
+Hansabit provides automation and digitalisation services. This monorepo contains the frontend (Next.js) and backend (FastAPI) applications and infrastructure for local development and production with Docker Compose and Caddy reverse proxy.
+
+## Voraussetzungen
+- Docker & Docker Compose
+- Make
+- Node.js 20+ for local frontend development
+- Python 3.11 for local backend development
+
+## Lokale Entwicklung
+
+### Mit Docker
+```bash
+cp .env.example .env
+make up
+```
+Die Seite ist unter http://localhost erreichbar. Die API unter http://localhost/api.
+
+### Ohne Docker
+1. Backend:
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp ../.env.example .env
+alembic upgrade head
+uvicorn app.main:app --reload
+```
+2. Frontend:
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## .env Variablen
+```
+POSTGRES_USER=hansabit
+POSTGRES_PASSWORD=change_me
+POSTGRES_DB=hansabit
+DATABASE_URL=postgresql+psycopg://hansabit:change_me@db:5432/hansabit
+REDIS_URL=redis://redis:6379/0
+SECRET_KEY=change_me
+JWT_EXPIRES_MINUTES=60
+BACKEND_CORS_ORIGINS=["https://hansabit.de","http://localhost:3000"]
+```
+`SECRET_KEY` generieren:
+```bash
+python -c "import secrets; print(secrets.token_hex(32))"
+```
+
+## Migrationen & Seed
+```bash
+make migrate
+make seed
+```
+Seed erstellt drei Beispiel-Cases und den Admin `admin@hansabit.de` mit Passwort `ChangeMe!123` (nur Entwicklung).
+
+## Tests
+```bash
+make test
+```
+
+## Deployment
+1. Server aufsetzen (z.B. Hetzner) und Docker installieren.
+2. Repository klonen und `.env` setzen.
+3. DNS A-Records für `hansabit.de` und `colabora.ge` auf Server-IP zeigen lassen.
+4. `make up` ausführen. Caddy holt automatische TLS-Zertifikate von Let's Encrypt.
+
+## Admin Login
+Nach Seed: `admin@hansabit.de` / `ChangeMe!123`.
+
+## Lighthouse
+Für lokale Tests:
+```bash
+npm install -g lighthouse
+lighthouse http://localhost --view
+```
+Zielscore ≥ 90 für Performance, Accessibility, Best Practices und SEO.
+
+## Sicherheit & Datenschutz
+- Argon2 Passwort-Hashing
+- HTTPS via Caddy
+- Keine Secrets im Repo
+- Im Projekt enthaltene Seiten: Impressum und Datenschutz mit Platz für Angaben.
+

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = app/alembic
+sqlalchemy.url = sqlite:///./test.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)s %(name)s %(message)s

--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -1,0 +1,27 @@
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+from app.core.config import settings
+from app.models import SQLModel
+
+config = context.config
+config.set_main_option('sqlalchemy.url', settings.database_url)
+fileConfig(config.config_file_name)
+target_metadata = SQLModel.metadata
+
+def run_migrations_offline():
+    context.configure(url=settings.database_url, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online():
+    connectable = engine_from_config(config.get_section(config.config_ini_section), prefix='sqlalchemy.', poolclass=pool.NullPool)
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/app/alembic/versions/0001_initial.py
+++ b/backend/app/alembic/versions/0001_initial.py
@@ -1,0 +1,41 @@
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'user',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('email', sa.String, nullable=False, unique=True),
+        sa.Column('hashed_password', sa.String, nullable=False),
+        sa.Column('is_active', sa.Boolean, default=True),
+        sa.Column('is_superuser', sa.Boolean, default=False),
+        sa.Column('created_at', sa.DateTime, server_default=sa.func.now()),
+    )
+    op.create_table(
+        'contact',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String, nullable=False),
+        sa.Column('email', sa.String, nullable=False),
+        sa.Column('message', sa.Text, nullable=False),
+        sa.Column('created_at', sa.DateTime, server_default=sa.func.now()),
+    )
+    op.create_table(
+        'case',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('title', sa.String, nullable=False),
+        sa.Column('description', sa.Text, nullable=False),
+        sa.Column('created_at', sa.DateTime, server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('case')
+    op.drop_table('contact')
+    op.drop_table('user')

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,0 +1,136 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm, OAuth2PasswordBearer
+from sqlmodel import Session, select
+from typing import List, Optional
+import redis
+from rq import Queue
+
+from app.db.session import get_session
+from app import models, schemas
+from app.core.security import get_password_hash, verify_password, create_access_token
+from app.core.config import settings
+from app.jobs.tasks import handle_contact
+
+router = APIRouter()
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
+
+
+@router.get("/health")
+def health() -> dict:
+    return {"status": "ok"}
+
+
+def get_current_user(token: str = Depends(oauth2_scheme), session: Session = Depends(get_session)) -> models.User:
+    from jose import JWTError, jwt
+
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, settings.secret_key, algorithms=["HS256"])
+        user_id = int(payload.get("sub"))
+    except Exception as e:
+        raise credentials_exception from e
+    user = session.get(models.User, user_id)
+    if not user:
+        raise credentials_exception
+    return user
+
+
+@router.post("/api/v1/auth/register", response_model=schemas.UserRead)
+def register(user_in: schemas.UserCreate, session: Session = Depends(get_session)):
+    if session.exec(select(models.User).where(models.User.email == user_in.email)).first():
+        raise HTTPException(status_code=400, detail="Email already registered")
+    user = models.User(email=user_in.email, hashed_password=get_password_hash(user_in.password))
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+@router.post("/api/v1/auth/login", response_model=schemas.Token)
+def login(form_data: OAuth2PasswordRequestForm = Depends(), session: Session = Depends(get_session)):
+    user = session.exec(select(models.User).where(models.User.email == form_data.username)).first()
+    if not user or not verify_password(form_data.password, user.hashed_password):
+        raise HTTPException(status_code=400, detail="Incorrect email or password")
+    access_token = create_access_token(str(user.id))
+    return schemas.Token(access_token=access_token)
+
+
+@router.get("/api/v1/auth/me", response_model=schemas.UserRead)
+def read_users_me(current_user: models.User = Depends(get_current_user)):
+    return current_user
+
+
+@router.post("/api/v1/contact", response_model=schemas.ContactRead, status_code=201)
+def create_contact(contact: schemas.ContactCreate, session: Session = Depends(get_session)):
+    db_contact = models.Contact.from_orm(contact)
+    session.add(db_contact)
+    session.commit()
+    session.refresh(db_contact)
+    q = Queue("default", connection=redis.from_url(settings.redis_url))
+    q.enqueue(handle_contact, db_contact.id)
+    return db_contact
+
+@router.get("/api/v1/contact", response_model=List[schemas.ContactRead])
+def list_contacts(current_user: models.User = Depends(get_current_user), session: Session = Depends(get_session)):
+    return session.exec(select(models.Contact)).all()
+@router.get("/api/v1/cases", response_model=List[schemas.CaseRead])
+def list_cases(
+    session: Session = Depends(get_session),
+    skip: int = 0,
+    limit: int = 10,
+    search: Optional[str] = None,
+    sort: Optional[str] = None,
+):
+    query = select(models.Case)
+    if search:
+        query = query.where(models.Case.title.contains(search))
+    if sort == "desc":
+        query = query.order_by(models.Case.created_at.desc())
+    else:
+        query = query.order_by(models.Case.created_at)
+    cases = session.exec(query.offset(skip).limit(limit)).all()
+    return cases
+
+
+@router.post("/api/v1/cases", response_model=schemas.CaseRead, status_code=201)
+def create_case(case: schemas.CaseCreate, session: Session = Depends(get_session), current_user: models.User = Depends(get_current_user)):
+    db_case = models.Case.from_orm(case)
+    session.add(db_case)
+    session.commit()
+    session.refresh(db_case)
+    return db_case
+
+
+@router.get("/api/v1/cases/{case_id}", response_model=schemas.CaseRead)
+def get_case(case_id: int, session: Session = Depends(get_session)):
+    case = session.get(models.Case, case_id)
+    if not case:
+        raise HTTPException(status_code=404, detail="Case not found")
+    return case
+
+
+@router.put("/api/v1/cases/{case_id}", response_model=schemas.CaseRead)
+def update_case(case_id: int, case_in: schemas.CaseCreate, session: Session = Depends(get_session), current_user: models.User = Depends(get_current_user)):
+    case = session.get(models.Case, case_id)
+    if not case:
+        raise HTTPException(status_code=404, detail="Case not found")
+    case.title = case_in.title
+    case.description = case_in.description
+    session.add(case)
+    session.commit()
+    session.refresh(case)
+    return case
+
+
+@router.delete("/api/v1/cases/{case_id}", status_code=204)
+def delete_case(case_id: int, session: Session = Depends(get_session), current_user: models.User = Depends(get_current_user)):
+    case = session.get(models.Case, case_id)
+    if not case:
+        raise HTTPException(status_code=404, detail="Case not found")
+    session.delete(case)
+    session.commit()
+    return None

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,0 +1,17 @@
+from pydantic import BaseSettings, AnyHttpUrl
+from typing import List
+
+
+class Settings(BaseSettings):
+    database_url: str
+    redis_url: str
+    secret_key: str
+    jwt_expires_minutes: int = 60
+    backend_cors_origins: List[AnyHttpUrl] = []
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+settings = Settings()

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from jose import jwt
+from passlib.context import CryptContext
+
+from .config import settings
+
+pwd_context = CryptContext(schemes=["argon2"], deprecated="auto")
+
+
+def create_access_token(subject: str, expires_delta: Optional[timedelta] = None) -> str:
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=settings.jwt_expires_minutes))
+    to_encode = {"sub": subject, "exp": expire}
+    return jwt.encode(to_encode, settings.secret_key, algorithm="HS256")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -1,0 +1,24 @@
+from app.db.session import engine
+from sqlmodel import Session
+from app import models
+from app.core.security import get_password_hash
+
+
+def init() -> None:
+    models.SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        if not session.exec(models.select(models.User)).first():
+            admin = models.User(email="admin@hansabit.de", hashed_password=get_password_hash("ChangeMe!123"), is_superuser=True)
+            session.add(admin)
+        if not session.exec(models.select(models.Case)).first():
+            cases = [
+                models.Case(title="Automatisierung", description="Workflow Digitalisierung"),
+                models.Case(title="Webplattform", description="Moderne Web App"),
+                models.Case(title="Integration", description="API Anbindung"),
+            ]
+            session.add_all(cases)
+        session.commit()
+
+
+if __name__ == "__main__":
+    init()

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,0 +1,14 @@
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.core.config import settings
+
+engine = create_engine(settings.database_url, echo=False)
+
+
+def init_db() -> None:
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session():
+    with Session(engine) as session:
+        yield session

--- a/backend/app/jobs/tasks.py
+++ b/backend/app/jobs/tasks.py
@@ -1,0 +1,7 @@
+import structlog
+
+logger = structlog.get_logger()
+
+
+def handle_contact(contact_id: int) -> None:
+    logger.info("contact.received", id=contact_id)

--- a/backend/app/jobs/worker.py
+++ b/backend/app/jobs/worker.py
@@ -1,0 +1,19 @@
+import structlog
+from rq import Connection, Worker
+import redis
+
+from app.core.config import settings
+
+logger = structlog.get_logger()
+
+
+def run() -> None:
+    redis_conn = redis.from_url(settings.redis_url)
+    with Connection(redis_conn):
+        worker = Worker(['default'])
+        logger.info("worker.start")
+        worker.work()
+
+
+if __name__ == "__main__":
+    run()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+import structlog
+
+from app.api.routes import router
+from app.core.config import settings
+
+logger = structlog.get_logger()
+
+app = FastAPI(title="Hansabit API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.backend_cors_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,6 @@
+from sqlmodel import SQLModel, select
+from .user import User
+from .contact import Contact
+from .case import Case
+
+__all__ = ["SQLModel", "select", "User", "Contact", "Case"]

--- a/backend/app/models/case.py
+++ b/backend/app/models/case.py
@@ -1,0 +1,10 @@
+from sqlmodel import SQLModel, Field
+from typing import Optional
+from datetime import datetime
+
+
+class Case(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    description: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/app/models/contact.py
+++ b/backend/app/models/contact.py
@@ -1,0 +1,11 @@
+from sqlmodel import SQLModel, Field
+from typing import Optional
+from datetime import datetime
+
+
+class Contact(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    email: str
+    message: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,12 @@
+from sqlmodel import SQLModel, Field
+from typing import Optional
+from datetime import datetime
+
+
+class User(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    email: str = Field(index=True, unique=True)
+    hashed_password: str
+    is_active: bool = True
+    is_superuser: bool = False
+    created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,0 +1,14 @@
+from .user import UserCreate, UserRead
+from .contact import ContactCreate, ContactRead
+from .case import CaseCreate, CaseRead
+from .token import Token
+
+__all__ = [
+    "UserCreate",
+    "UserRead",
+    "ContactCreate",
+    "ContactRead",
+    "CaseCreate",
+    "CaseRead",
+    "Token",
+]

--- a/backend/app/schemas/case.py
+++ b/backend/app/schemas/case.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from datetime import datetime
+from typing import Optional
+
+
+class CaseCreate(BaseModel):
+    title: str
+    description: str
+
+
+class CaseRead(BaseModel):
+    id: int
+    title: str
+    description: str
+    created_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/backend/app/schemas/contact.py
+++ b/backend/app/schemas/contact.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel, EmailStr
+from datetime import datetime
+
+
+class ContactCreate(BaseModel):
+    name: str
+    email: EmailStr
+    message: str
+
+
+class ContactRead(BaseModel):
+    id: int
+    name: str
+    email: EmailStr
+    message: str
+    created_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/backend/app/schemas/token.py
+++ b/backend/app/schemas/token.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, EmailStr
+from typing import Optional
+
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class UserRead(BaseModel):
+    id: int
+    email: EmailStr
+    is_superuser: bool
+
+    class Config:
+        orm_mode = True

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,40 @@
+[project]
+name = "hansabit-backend"
+version = "0.1.0"
+description = "Backend for Hansabit"
+authors = [{name = "Hansabit"}]
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]",
+    "sqlmodel",
+    "pydantic[email]",
+    "psycopg[binary]",
+    "alembic",
+    "redis",
+    "rq",
+    "python-multipart",
+    "passlib[argon2]",
+    "python-jose[cryptography]",
+    "structlog",
+]
+
+[project.optional-dependencies]
+dev = [
+    "black",
+    "ruff",
+    "mypy",
+    "pytest",
+    "httpx",
+]
+
+[tool.black]
+line-length = 88
+
+[tool.ruff]
+select = ["E", "F", "B", "Q", "W"]
+line-length = 88
+
+[tool.mypy]
+plugins = []
+strict = true

--- a/backend/tests/test_contact.py
+++ b/backend/tests/test_contact.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_health():
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+def test_contact_create(monkeypatch):
+    def fake_enqueue(func, contact_id):
+        return None
+    monkeypatch.setattr("app.api.routes.Queue.enqueue", lambda self, func, contact_id: fake_enqueue(func, contact_id))
+    payload = {"name": "Max", "email": "max@example.com", "message": "Hallo"}
+    r = client.post("/api/v1/contact", json=payload)
+    assert r.status_code == 201
+    data = r.json()
+    assert data["name"] == "Max"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,77 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD', 'pg_isready', '-U', '${POSTGRES_USER}']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  redis:
+    image: redis:7
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  backend:
+    build: ./backend
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      REDIS_URL: ${REDIS_URL}
+      SECRET_KEY: ${SECRET_KEY}
+      BACKEND_CORS_ORIGINS: ${BACKEND_CORS_ORIGINS}
+      JWT_EXPIRES_MINUTES: ${JWT_EXPIRES_MINUTES}
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8000/api/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  worker:
+    build: ./backend
+    command: python -m app.jobs.worker
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      REDIS_URL: ${REDIS_URL}
+      SECRET_KEY: ${SECRET_KEY}
+    depends_on:
+      - backend
+      - redis
+  frontend:
+    build: ./frontend
+    command: npm run start
+    environment:
+      NEXT_PUBLIC_API_URL: /api
+    depends_on:
+      - backend
+  caddy:
+    image: caddy:2
+    ports:
+      - '80:80'
+      - '443:443'
+    volumes:
+      - caddy_data:/data
+      - caddy_config:/config
+      - ./infra/Caddyfile:/etc/caddy/Caddyfile
+    depends_on:
+      - frontend
+      - backend
+volumes:
+  postgres_data:
+  redis_data:
+  caddy_data:
+  caddy_config:

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,0 +1,13 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    serverActions: true,
+  },
+  i18n: {
+    locales: ['de', 'en'],
+    defaultLocale: 'de',
+  },
+}
+
+export default nextConfig

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "hansabit-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "typescript": "5.2.2",
+    "tailwindcss": "3.3.5",
+    "postcss": "8.4.21",
+    "autoprefixer": "10.4.14",
+    "zod": "3.22.4",
+    "react-hook-form": "7.45.0",
+    "@tanstack/react-query": "4.29.0",
+    "@shadcn/ui": "0.1.0"
+  },
+  "devDependencies": {
+    "eslint": "8.49.0",
+    "eslint-config-next": "14.0.0",
+    "prettier": "3.0.0",
+    "vitest": "0.34.0",
+    "@testing-library/react": "14.0.0",
+    "@testing-library/jest-dom": "6.0.0",
+    "jsdom": "22.1.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -1,0 +1,17 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+export default function Dashboard() {
+  const [contacts, setContacts] = useState([])
+  useEffect(() => {
+    fetch('/api/v1/contact', { credentials: 'include' })
+      .then(r => r.json())
+      .then(setContacts)
+  }, [])
+  return (
+    <main className="p-8">
+      <h1 className="text-3xl font-bold mb-4">Admin Dashboard</h1>
+      <pre>{JSON.stringify(contacts, null, 2)}</pre>
+    </main>
+  )
+}

--- a/frontend/src/app/(marketing)/blog/page.tsx
+++ b/frontend/src/app/(marketing)/blog/page.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function Blog() {
+  return (
+    <main className="p-8">
+      <h1 className="text-3xl font-bold mb-4">Blog</h1>
+      <ul className="list-disc pl-6">
+        <li><Link href="/blog/posts/hello">Erster Beitrag</Link></li>
+      </ul>
+    </main>
+  )
+}

--- a/frontend/src/app/(marketing)/blog/posts/hello.mdx
+++ b/frontend/src/app/(marketing)/blog/posts/hello.mdx
@@ -1,0 +1,7 @@
+---
+title: "Willkommen"
+---
+
+# Willkommen
+
+Dieser Beitrag beschreibt Neuigkeiten von Hansabit.

--- a/frontend/src/app/(marketing)/datenschutz/page.tsx
+++ b/frontend/src/app/(marketing)/datenschutz/page.tsx
@@ -1,0 +1,8 @@
+export default function Datenschutz() {
+  return (
+    <main className="p-8">
+      <h1 className="text-3xl font-bold mb-4">Datenschutz</h1>
+      <p>Hier stehen Informationen zum Datenschutz und zur Auftragsverarbeitung.</p>
+    </main>
+  )
+}

--- a/frontend/src/app/(marketing)/impressum/page.tsx
+++ b/frontend/src/app/(marketing)/impressum/page.tsx
@@ -1,0 +1,8 @@
+export default function Impressum() {
+  return (
+    <main className="p-8">
+      <h1 className="text-3xl font-bold mb-4">Impressum</h1>
+      <p>Platz für Firmenangaben und rechtliche Hinweise.</p>
+    </main>
+  )
+}

--- a/frontend/src/app/(marketing)/kontakt/page.tsx
+++ b/frontend/src/app/(marketing)/kontakt/page.tsx
@@ -1,0 +1,10 @@
+import { ContactForm } from "../../../components/ui/ContactForm"
+
+export default function Kontakt() {
+  return (
+    <main className="p-8">
+      <h1 className="text-3xl font-bold mb-4">Kontakt</h1>
+      <ContactForm />
+    </main>
+  )
+}

--- a/frontend/src/app/(marketing)/leistungen/page.tsx
+++ b/frontend/src/app/(marketing)/leistungen/page.tsx
@@ -1,0 +1,8 @@
+export default function Leistungen() {
+  return (
+    <main className="p-8">
+      <h1 className="text-3xl font-bold mb-4">Leistungen</h1>
+      <p>Beratung, Entwicklung und Betrieb moderner Softwarelösungen.</p>
+    </main>
+  )
+}

--- a/frontend/src/app/(marketing)/preise/page.tsx
+++ b/frontend/src/app/(marketing)/preise/page.tsx
@@ -1,0 +1,8 @@
+export default function Preise() {
+  return (
+    <main className="p-8">
+      <h1 className="text-3xl font-bold mb-4">Preise</h1>
+      <p>Transparente Pakete für Projekte jeder Größe.</p>
+    </main>
+  )
+}

--- a/frontend/src/app/(marketing)/referenzen/page.tsx
+++ b/frontend/src/app/(marketing)/referenzen/page.tsx
@@ -1,0 +1,8 @@
+export default function Referenzen() {
+  return (
+    <main className="p-8">
+      <h1 className="text-3xl font-bold mb-4">Referenzen</h1>
+      <p>Ausgewählte Kundenprojekte und Erfolgsgeschichten.</p>
+    </main>
+  )
+}

--- a/frontend/src/app/api/health/route.ts
+++ b/frontend/src/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  return NextResponse.json({ status: 'ok' })
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,0 +1,24 @@
+import "../styles/globals.css"
+import { ReactNode } from 'react'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Hansabit – Automatisierung und Digitalisierung',
+  description: 'Moderne Lösungen für Unternehmen',
+  openGraph: {
+    title: 'Hansabit',
+    description: 'Automatisierung und Digitalisierung',
+    url: 'https://hansabit.de',
+    siteName: 'Hansabit',
+  },
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="de">
+      <body className="min-h-screen flex flex-col">
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link'
+import { ContactForm } from '../components/ui/ContactForm'
+
+export default function Home() {
+  return (
+    <main className="flex-1">
+      <section className="bg-gray-50 py-20 text-center">
+        <h1 className="text-4xl font-bold mb-4">Automation für Ihr Unternehmen</h1>
+        <p className="mb-6">Wir digitalisieren Prozesse und schaffen Freiräume.</p>
+        <Link href="/kontakt" className="bg-blue-600 text-white px-4 py-2 rounded">Kontakt</Link>
+      </section>
+      <section className="p-8 grid md:grid-cols-3 gap-6">
+        <div className="shadow p-4 rounded">
+          <h2 className="font-semibold mb-2">Beratung</h2>
+          <p>Wir analysieren Ihre Abläufe und finden Potenziale.</p>
+        </div>
+        <div className="shadow p-4 rounded">
+          <h2 className="font-semibold mb-2">Entwicklung</h2>
+          <p>Individuelle Softwarelösungen für Ihren Bedarf.</p>
+        </div>
+        <div className="shadow p-4 rounded">
+          <h2 className="font-semibold mb-2">Betrieb</h2>
+          <p>Wir betreuen Ihre Systeme langfristig.</p>
+        </div>
+      </section>
+      <section className="p-8" id="kontakt">
+        <h2 className="text-2xl font-bold mb-4">Kontakt</h2>
+        <ContactForm />
+      </section>
+    </main>
+  )
+}

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,7 @@
+import { ButtonHTMLAttributes } from 'react'
+
+export function Button(props: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button className="bg-blue-600 text-white px-4 py-2 rounded" {...props} />
+  )
+}

--- a/frontend/src/components/ui/ContactForm.tsx
+++ b/frontend/src/components/ui/ContactForm.tsx
@@ -1,0 +1,34 @@
+'use client'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Input } from './Input'
+import { Button } from './Button'
+import { apiFetch } from '../../lib/api'
+
+const schema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  message: z.string().min(1),
+})
+
+type FormData = z.infer<typeof schema>
+
+export function ContactForm() {
+  const { register, handleSubmit, reset, formState: { errors } } = useForm<FormData>({ resolver: zodResolver(schema) })
+  const onSubmit = async (data: FormData) => {
+    await apiFetch('/api/v1/contact', { method: 'POST', body: JSON.stringify(data) })
+    reset()
+  }
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 max-w-md">
+      <Input placeholder="Name" {...register('name')} />
+      {errors.name && <span className="text-red-500">{errors.name.message}</span>}
+      <Input placeholder="Email" type="email" {...register('email')} />
+      {errors.email && <span className="text-red-500">{errors.email.message}</span>}
+      <textarea className="border p-2 w-full rounded" placeholder="Nachricht" {...register('message')} />
+      {errors.message && <span className="text-red-500">{errors.message.message}</span>}
+      <Button type="submit">Senden</Button>
+    </form>
+  )
+}

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,0 +1,5 @@
+import { InputHTMLAttributes } from 'react'
+
+export function Input(props: InputHTMLAttributes<HTMLInputElement>) {
+  return <input className="border p-2 w-full rounded" {...props} />
+}

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,0 +1,8 @@
+export const messages = {
+  de: {
+    contact: 'Kontakt',
+  },
+  en: {
+    contact: 'Contact',
+  },
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,10 @@
+export async function apiFetch(path: string, options?: RequestInit) {
+  const res = await fetch(path, {
+    headers: { 'Content-Type': 'application/json' },
+    ...options,
+  })
+  if (!res.ok) throw new Error('API error')
+  return res.json()
+}
+
+export const fetcher = (url: string) => apiFetch(url)

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply text-gray-900;
+}

--- a/frontend/src/tests/api.test.ts
+++ b/frontend/src/tests/api.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect, vi } from 'vitest'
+import { apiFetch } from '../lib/api'
+
+describe('apiFetch', () => {
+  it('throws on bad status', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false })
+    await expect(apiFetch('/')).rejects.toThrow()
+  })
+})

--- a/frontend/src/tests/contactform.test.tsx
+++ b/frontend/src/tests/contactform.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react'
+import { ContactForm } from '../components/ui/ContactForm'
+import { describe, it, expect } from 'vitest'
+
+describe('ContactForm', () => {
+  it('has submit button', () => {
+    render(<ContactForm />)
+    expect(screen.getByText('Senden')).toBeDefined()
+  })
+})

--- a/frontend/src/tests/home.test.tsx
+++ b/frontend/src/tests/home.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react'
+import Home from '../app/page'
+import { describe, it, expect } from 'vitest'
+
+describe('Home', () => {
+  it('renders heading', () => {
+    render(<Home />)
+    expect(screen.getByText('Automation für Ihr Unternehmen')).toBeDefined()
+  })
+})

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,10 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+export default config

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -1,0 +1,17 @@
+{
+    email admin@hansabit.de
+}
+
+hansabit.de, colabora.ge {
+    encode gzip
+    tls {
+        protocols tls1.2 tls1.3
+    }
+    @api path /api/*
+    handle @api {
+        reverse_proxy backend:8000
+    }
+    handle {
+        reverse_proxy frontend:3000
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold backend with FastAPI, SQLModel, JWT auth, Alembic, RQ worker
- scaffold frontend with Next.js 14, Tailwind, contact form and marketing pages
- add Docker Compose infrastructure with Caddy reverse proxy and makefile helpers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e671b372c83269d520871abfbc824